### PR TITLE
cairo 1.16.0: x11_gui_rebuilds

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -38,9 +38,6 @@ bash autogen.sh
 
 find $PREFIX -name '*.la' -delete
 
-# Ensure PKG_CONFIG_PATH includes $PREFIX/lib/pkgconfig for pkg-config detection (e.g., glib)
-export PKG_CONFIG_PATH=${PKG_CONFIG_PATH:-}:${PREFIX}/lib/pkgconfig:$BUILD_PREFIX/$BUILD/sysroot/usr/lib64/pkgconfig:$BUILD_PREFIX/$BUILD/sysroot/usr/share/pkgconfig
-
 ./configure \
     --prefix="${PREFIX}" \
     --enable-warnings \
@@ -56,7 +53,5 @@ make -j${CPU_COUNT}
 # Hangs for > 10 minutes on Linux
 #make check -j${CPU_COUNT}
 make install -j${CPU_COUNT}
-
-ldd $PREFIX/lib/libcairo.so
 
 find $PREFIX -name '*.la' -delete

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -56,4 +56,7 @@ make -j${CPU_COUNT}
 # Hangs for > 10 minutes on Linux
 #make check -j${CPU_COUNT}
 make install -j${CPU_COUNT}
+
+ldd $PREFIX/lib/libcairo.so
+
 find $PREFIX -name '*.la' -delete

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -45,7 +45,8 @@ find $PREFIX -name '*.la' -delete
     --enable-pdf \
     --enable-svg \
     --disable-gtk-doc \
-    ${CONFIGURE_OTHER_ARGS[@]}
+    --enable-gl \
+    "${CONFIGURE_OTHER_ARGS[@]}"
 
 make -j${CPU_COUNT}
 # FAIL: check-link on OS X

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -37,6 +37,10 @@ fi
 bash autogen.sh
 
 find $PREFIX -name '*.la' -delete
+
+# Ensure PKG_CONFIG_PATH includes $PREFIX/lib/pkgconfig for pkg-config detection (e.g., glib)
+export PKG_CONFIG_PATH=${PKG_CONFIG_PATH:-}:${PREFIX}/lib/pkgconfig:$BUILD_PREFIX/$BUILD/sysroot/usr/lib64/pkgconfig:$BUILD_PREFIX/$BUILD/sysroot/usr/share/pkgconfig
+
 ./configure \
     --prefix="${PREFIX}" \
     --enable-warnings \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -45,7 +45,6 @@ find $PREFIX -name '*.la' -delete
     --enable-pdf \
     --enable-svg \
     --disable-gtk-doc \
-    --enable-gl \
     "${CONFIGURE_OTHER_ARGS[@]}"
 
 make -j${CPU_COUNT}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,13 +48,9 @@ requirements:
     - libpng 1.6
     - libxcb               # [linux]
     - pixman 0.40
-    - xorg-libice          # [linux]
-    - xorg-libsm           # [linux]
     - xorg-libx11          # [linux]
-    - xorg-libxau          # [linux]
     - xorg-libxext         # [linux]
     - xorg-libxrender      # [linux]
-    - xorg-xorgproto       # [linux]
     - zlib 1.2.*
   run:
     - fontconfig
@@ -68,11 +64,6 @@ requirements:
 test:
   requires:
     - pkg-config
-    # The packages below are needed for the pkg-config invocations
-    - expat
-    - glib
-    - xorg-xorgproto       # [linux]
-    - zlib
   commands:
     # Check commands.
     - cairo-trace --help  # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,14 +44,14 @@ requirements:
   host:
     - fontconfig 2.14
     - freetype 2.10
-    - glib 2
-    - libpng 1.6
-    - libxcb               # [linux]
-    - pixman 0.40
-    - xorg-libx11          # [linux]
-    - xorg-libxext         # [linux]
-    - xorg-libxrender      # [linux]
-    - zlib 1.2.*
+    - glib {{ glib }}
+    - libpng {{ libpng }}
+    - libxcb {{ libxcb }}                    # [linux]
+    - pixman {{ pixman }}
+    - xorg-libx11 {{ xorg_libx11 }}          # [linux]
+    - xorg-libxext {{ xorg_libxext }}        # [linux]
+    - xorg-libxrender {{ xorg_libxrender }}  # [linux]
+    - zlib {{ zlib }}
   run:
     - fontconfig
     - freetype

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - windows_enable_freetype.patch  # [win]
     - 0001-Ref-and-destroy-the-cairo-surface-handed-off-to-Core.patch  # [osx]
 build:
-  number: 5
+  number: 6
   run_exports:
     - {{ pin_subpackage('cairo') }}
   missing_dso_whitelist:         # [linux and x86_64]
@@ -37,28 +37,28 @@ requirements:
     - xz  # [not win]
     - m2w64-xz  # [win]
     - pthread-stubs         # [linux]
-    - xcb-proto             # [linux]
     - {{ compiler('c') }}
     - patch     # [osx]
     - m2-patch  # [win]
 
   host:
-    - freetype 2.10
     - fontconfig 2.14
+    - freetype 2.10
     - glib 2
     - libpng 1.6
-    - libxcb 1.15               # [linux]
+    - libxcb               # [linux]
     - pixman 0.40
+    - xorg-libice          # [linux]
+    - xorg-libsm           # [linux]
+    - xorg-libx11          # [linux]
+    - xorg-libxau          # [linux]
+    - xorg-libxext         # [linux]
+    - xorg-libxrender      # [linux]
+    - xorg-xorgproto       # [linux]
     - zlib 1.2.*
-
-    - xorg-libx11
-    - xorg-libxau
-    - xorg-libxext
-    - xorg-libxrender
-    - xorg-xproto
   run:
-    - freetype
     - fontconfig
+    - freetype
     - glib
     - libpng
     - libxcb                # [linux]
@@ -66,6 +66,13 @@ requirements:
     - zlib
 
 test:
+  requires:
+    - pkg-config
+    # The packages below are needed for the pkg-config invocations
+    - expat
+    - glib
+    - xorg-xorgproto       # [linux]
+    - zlib
   commands:
     # Check commands.
     - cairo-trace --help  # [not win]
@@ -98,6 +105,13 @@ test:
 
     # check that cairo was built with fontconfig support
     - grep -q "CAIRO_HAS_FC_FONT 1" $PREFIX/include/cairo/cairo-features.h  # [unix]
+    
+    # verify pkg-config functionality
+    - export PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig        # [not win]
+    - set "PKG_CONFIG_PATH=%LIBRARY_LIB%\\pkgconfig"      # [win]
+    - pkg-config --cflags cairo
+    - pkg-config --cflags cairo-fc                         # [not win]
+    - pkg-config --cflags cairo-gobject
 
 about:
   home: https://cairographics.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,7 +55,6 @@ requirements:
   run:
     - fontconfig
     - freetype
-    - glib
     - libpng
     - libxcb                # [linux]
     - pixman

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,11 +39,6 @@ requirements:
     - pthread-stubs         # [linux]
     - xcb-proto             # [linux]
     - {{ compiler('c') }}
-    - {{ cdt('libx11-devel') }}          # [linux]
-    - {{ cdt('libxau-devel') }}          # [linux]
-    - {{ cdt('libxext-devel') }}         # [linux]
-    - {{ cdt('libxrender-devel') }}      # [linux]
-    - {{ cdt('xorg-x11-proto-devel') }}  # [linux]
     - patch     # [osx]
     - m2-patch  # [win]
 
@@ -56,6 +51,11 @@ requirements:
     - pixman 0.40
     - zlib 1.2.*
 
+    - xorg-libx11
+    - xorg-libxau
+    - xorg-libxext
+    - xorg-libxrender
+    - xorg-xproto
   run:
     - freetype
     - fontconfig


### PR DESCRIPTION

**Destination channel:** main

### Links

- [PKG-7754](https://anaconda.atlassian.net/browse/PKG-7754)
- [Upstream repository](https://gitlab.freedesktop.org/cairo/cairo)

### Explanation of changes:

- Bump the build number to 6
- Move X11 dependencies from CDTs in build section to regular packages in host section:
  - Replace `{{ cdt('libxau-devel') }}` with `xorg-libxau`
  - Replace `{{ cdt('libxext-devel') }}` with `xorg-libxext`
  - Replace `{{ cdt('libx11-devel') }}` with `xorg-libx11`
  - Replace `{{ cdt('libxrender-devel') }}` with `xorg-libxrender`
  - Replace `{{ cdt('xorg-x11-proto-devel') }}` with `xorg-xorgproto`
  - Add additional X11 dependencies: `xorg-libice` and `xorg-libsm` (based on the conda-forge recipe)
- Remove `xcb-proto` as it's not needed
- All X11/Xorg packages are constrained with `# [linux]` to ensure they're only included on Linux platforms
- Update the test section with package requirements and pkg-config verification commands

### Notes:

- It's an automated migration/rebuild for the `x11_gui_rebuilds` group at stage 1:

```
  x11_gui_rebuilds:
    stages:
    - stage: 0
      packages:
      - tk
      - libxkbcommon
      - pango
      - at-spi2-core
      - at-spi2-atk
      - tktable
    - stage: 1
      packages:
      - gtk2
      - gtk3
      - gstreamer
      - harfbuzz
      - cairo
    ...
```


[PKG-7754]: https://anaconda.atlassian.net/browse/PKG-7754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ