### PR TITLE
cairo rebuild with win-arm64 support

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,8 +28,8 @@ requirements:
     - ninja-base
     - {{ stdlib('c') }}
     - {{ compiler('c') }}
+    - meson  # analint: python_build_tools_in_host
   host:
-    - meson
     - fontconfig {{ fontconfig }}
     - freetype {{ freetype }}
     - glib {{ glib }}
@@ -45,13 +45,13 @@ requirements:
     - freetype
     - libpng
     - libxcb  # [linux]
-    - glib
     - pixman
     - zlib
 
 test:
   requires:
     - pkg-config
+    - glib
   commands:
     # Check commands.
     - cairo-trace --help  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,6 +47,7 @@ requirements:
     - freetype
     - libpng
     - libxcb  # [linux]
+    - glib
     - pixman
     - zlib
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - patches/unvendor.patch  
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('cairo') }}
   missing_dso_whitelist:         # [linux and x86_64]
@@ -26,12 +26,10 @@ requirements:
   build:
     - pkg-config
     - ninja-base
-    - meson
-    - xz  # [unix]
-    - m2w64-xz  # [win]
     - {{ stdlib('c') }}
     - {{ compiler('c') }}
   host:
+    - meson
     - fontconfig {{ fontconfig }}
     - freetype {{ freetype }}
     - glib {{ glib }}
@@ -59,14 +57,9 @@ test:
     - cairo-trace --help  # [unix]
 
     # Verify libraries.
-    {% set cairo_libs = [
-            "libcairo",
-            "libcairo-gobject",
-            "libcairo-script-interpreter",
-    ] %}
-    {% for each_cairo_lib in cairo_libs %}
-    - test -f $PREFIX/lib/{{ each_cairo_lib }}${SHLIB_EXT}  # [unix]
-    {% endfor %}
+    - test -f $PREFIX/lib/libcairo${SHLIB_EXT}  # [unix]
+    - test -f $PREFIX/lib/libcairo-gobject${SHLIB_EXT}  # [unix]
+    - test -f $PREFIX/lib/libcairo-script-interpreter${SHLIB_EXT}  # [unix]
     - if not exist %LIBRARY_BIN%\\cairo*.dll exit 1          # [win]
     - if not exist %LIBRARY_LIB%\\cairo.lib exit 1          # [win]
     - if not exist %LIBRARY_BIN%\\cairo-gobject*.dll exit 1  # [win]


### PR DESCRIPTION
cario rebuild: win-arm64 support

**Destination channel:**  defaults

### Links

- [PKG-15407](https://anaconda.atlassian.net/browse/PKG-15407) 


### Explanation of changes:

- Bump build number
- Remove unneeded xz deps
- Add glib which is needed in test
- Fix lints


[PKG-15407]: https://anaconda.atlassian.net/browse/PKG-15407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ